### PR TITLE
Add imports to the first group

### DIFF
--- a/fix.go
+++ b/fix.go
@@ -30,7 +30,11 @@ func fixImports(f *ast.File) {
 			f.Imports = append(f.Imports, is)
 		}
 		gd0 := genDecls[0]
-		gd0.Specs = append(gd0.Specs, is)
+		// prepend the spec to the beginning of the list
+		gd0.Specs = append(gd0.Specs, nil)
+		copy(gd0.Specs[1:], gd0.Specs)
+		gd0.Specs[0] = is
+
 		if len(gd0.Specs) > 1 && gd0.Lparen == 0 {
 			gd0.Lparen = 1 // something not zero
 		}

--- a/fix_test.go
+++ b/fix_test.go
@@ -154,6 +154,36 @@ func bar() {
 }
 `,
 	},
+
+	// Add to first import group
+	{
+		name: "first_group",
+		in: `package foo
+
+import (
+	"fmt"
+
+	"bytes"
+)
+
+func bar() {
+	_, _, _ = fmt.Println, bytes.Buffer, math.Pow
+}
+`,
+		out: `package foo
+
+import (
+	"math"
+	"fmt"
+
+	"bytes"
+)
+
+func bar() {
+	_, _, _ = fmt.Println, bytes.Buffer, math.Pow
+}
+`,
+	},
 }
 
 func TestFixImports(t *testing.T) {


### PR DESCRIPTION
Not sure if you're interested in this one.

This prevents disruption of import styles like:

``` go
    import (
        "bytes"
        "fmt"

        "github.com/external/1"
        "github.com/external/2"
    )
```
