### PR TITLE
fix importpath for windows.

### DIFF
--- a/fix.go
+++ b/fix.go
@@ -176,8 +176,9 @@ func loadPkgIndex() {
 
 var fset = token.NewFileSet()
 
-func loadPkg(wg *sync.WaitGroup, root, importpath string) {
-	shortName := path.Base(importpath)
+func loadPkg(wg *sync.WaitGroup, root, pkgrelpath string) {
+	importpath := strings.Replace(pkgrelpath, "\\", "/", -1)
+	shortName := filepath.Base(importpath)
 
 	dir := filepath.Join(root, importpath)
 	pkgIndex.Lock()

--- a/fix.go
+++ b/fix.go
@@ -177,7 +177,7 @@ func loadPkgIndex() {
 var fset = token.NewFileSet()
 
 func loadPkg(wg *sync.WaitGroup, root, pkgrelpath string) {
-	importpath := strings.Replace(pkgrelpath, "\\", "/", -1)
+	importpath := filepath.ToSlash(pkgrelpath)
 	shortName := filepath.Base(importpath)
 
 	dir := filepath.Join(root, importpath)

--- a/fix_test.go
+++ b/fix_test.go
@@ -447,7 +447,6 @@ func f() {
 }
 `,
 	},
-
 }
 
 func TestFixImports(t *testing.T) {
@@ -459,7 +458,7 @@ func TestFixImports(t *testing.T) {
 		"user":      "appengine/user",
 		"zip":       "archive/zip",
 		"bytes":     "bytes",
-		"snappy": "code.google.com/p/snappy-go/snappy",
+		"snappy":    "code.google.com/p/snappy-go/snappy",
 	}
 	findImport = func(pkgName string, symbols map[string]bool) (string, error) {
 		return simplePkgs[pkgName], nil
@@ -487,11 +486,13 @@ func TestFindImportGoPath(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer os.RemoveAll(goroot)
-	bytesDir := filepath.Join(goroot, "src", "pkg", "bytes")
+	// Test against imaginary bits/bytes package in std lib
+	bytesDir := filepath.Join(goroot, "src", "pkg", "bits", "bytes")
 	if err := os.MkdirAll(bytesDir, 0755); err != nil {
 		t.Fatal(err)
 	}
 	bytesSrcPath := filepath.Join(bytesDir, "bytes.go")
+	bytesPkgPath := "bits/bytes"
 	bytesSrc := []byte(`package bytes
 
 type Buffer2 struct {}
@@ -512,8 +513,8 @@ type Buffer2 struct {}
 	if err != nil {
 		t.Fatal(err)
 	}
-	if got != "bytes" {
-		t.Errorf(`findImportGoPath("bytes", Buffer2 ...)=%q, want "bytes"`, got)
+	if got != bytesPkgPath {
+		t.Errorf(`findImportGoPath("bytes", Buffer2 ...)=%q, want "%s"`, got, bytesPkgPath)
 	}
 
 	got, err = findImportGoPath("bytes", map[string]bool{"Missing": true})


### PR DESCRIPTION
issue #15

On windows goimports fails to import packages having path separator.
goimports currently uses dir Name for import path and path.Base for indexing key. Both these to be fixed to work on windows.
