### PR TITLE
Support packages with names not matching their directory

### DIFF
--- a/README
+++ b/README
@@ -25,17 +25,3 @@ For vim, set "gofmt_command" to "goimports":
 For other editors, you probably know what to do.
 
 Happy hacking!
-
-Caveats:
-
-For removal, it assumes the import path base matches the package name,
-which is best practice anyway, like:
-
-    import "github.com/you/foo" // assumes this is package "foo"
-
-If they don't match, explicitly name the package name in your import
-line:
-
-    import foo "github.com/you/not-quite-foo"
-
-These caveats might be fixed.


### PR DESCRIPTION
That is, packages with a name that doesn't match the base of import path.
It uses build.Import() to figure out the package name from the source code.

Fixes bradfitz/goimports#19.

It's still fast, but there'll obviously be a performance hit. I don't see a faster way of solving this in the worst-case, but I am open to suggestions. There are definitely opportunities for optimization for average cases.
