### PR TITLE
Adds support for (renamed) packages that begin with numbers.

### DIFF
--- a/fix.go
+++ b/fix.go
@@ -220,7 +220,7 @@ func loadPkg(wg *sync.WaitGroup, root, pkgrelpath string) {
 		if name == "" {
 			continue
 		}
-		if c := name[0]; c == '.' || ('0' <= c && c <= '9') {
+		if c := name[0]; c == '.' {
 			continue
 		}
 		if child.IsDir() {


### PR DESCRIPTION
Previously, goimports had a caveat where it only supported package that were named after the base of their import path. Given that, a reasonable optimization was to skip all folders that begin with a number, because Go packages may not begin with a number, so such folders could not have been supported packages.

Now that the caveat is removed, it's possible to have an import path, e.g., `github.com/something/123` and inside the folder `123`, there may be a valid `package go123`.

This fix allows goimports to properly support such packages.
