### PR TITLE
Updated GoSublime installation reference link.

### DIFF
--- a/README
+++ b/README
@@ -29,7 +29,7 @@ For vim, set "gofmt_command" to "goimports":
     etc
 
 For GoSublime, follow the steps described here:
-    http://mdwhatcott.wordpress.com/2013/12/15/installing-and-enabling-goimports-with-gosublime/
+    http://michaelwhatcott.com/gosublime-goimports/
 
 For other editors, you probably know what to do.
 


### PR DESCRIPTION
Any chance that this can still be updated here? And here too: https://code.google.com/p/go/source/browse/cmd/goimports/doc.go?repo=tools
